### PR TITLE
Unlink temp file after loading on POSIX.

### DIFF
--- a/src/main/java/cz/adamh/utils/NativeUtils.java
+++ b/src/main/java/cz/adamh/utils/NativeUtils.java
@@ -24,7 +24,6 @@
 package cz.adamh.utils;
 
 import java.io.*;
-import java.net.URI;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.ProviderNotFoundException;
@@ -67,7 +66,7 @@ public class NativeUtils {
         String[] parts = path.split("/");
         String filename = (parts.length > 1) ? parts[parts.length - 1] : null;
  
-        // Split filename to prexif and suffix (extension)
+        // Split filename to prefix and suffix (extension)
         String prefix = "";
         String suffix = null;
         if (filename != null) {
@@ -119,7 +118,7 @@ public class NativeUtils {
             while ((readBytes = is.read(buffer)) != -1) {
                 os.write(buffer, 0, readBytes);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             temp.delete();
             throw e;
         } finally {


### PR DESCRIPTION
## Unlink temp file after loading on POSIX
* Unlink the temporary library file after the last file descriptor to it is opened (`System.load(temp.getAbsolutePath())`) on systems that appear to be POSIX compliant.

### Reasoning:
Calling `temp.deleteOnExit()` will not ensure clean up if the process exits abnormally, for example: `assert()` resulting in `SIGABRT`, segmentation fault (likely during development with JNI), `SIGKILL` from user.

### Considerations:
This should be 100% safe on POSIX systems so long as:
* The temporary file is created on a POSIX _and/or_ local file-system (SMB not OK, FAT32 is OK, ext2/3/4 or Linux's tmpfs is excellent).  This should almost always be true, and if it were not it would in all likely-hood create all sorts of other issues for the user as many programs rely on this behaviour, not to mention the security considerations of mounting a networked file system on `/tmp`.
* Java calls `unlink` (SVr4, 4.3BSD, POSIX.1-2001, POSIX.1-2008) or `unlinkat` (POSIX.1-2008) instead of `remove` (POSIX.1-2001, POSIX.1-2008, C89, C99, 4.3BSD).  OpenJDK/JRE calls unlink on my system, `remove` should also be safe on most systems, but the behaviour of `remove` on open files is [undefined in POSIX](https://www.securecoding.cert.org/confluence/display/c/FIO08-C.+Take+care+when+calling+remove%28%29+on+an+open+file).